### PR TITLE
Restore window.basePath in layout.erb required for request details popups.

### DIFF
--- a/site-overlay/layout.erb
+++ b/site-overlay/layout.erb
@@ -53,6 +53,10 @@
       </div>
     </footer>
 
+    <script>
+      window.basePath = '/inferno';
+    </script>
+
     <!-- Optional JavaScript -->
     <!-- jQuery first, then Tether.js, then Popper.js, then Bootstrap JS -->
     <script src="/inferno/static/js/jquery-3.2.1.min.js"></script>


### PR DESCRIPTION
This fixes the bug where clicking on details of a test after it has run causes no popup to display.

The `window.basePath` variable needs to be set in `layout.erb` in order for the test details popups to function correctly.  This allows us to deploy the application at `/` or `/inferno` or `/any/arbitrary/path`, because some popups dynamically load data from the server using javascript and need to know the root of the application.

It looks like this wasn't carried over from the base layout.erb to the site overlay version, perhaps because this customized version was created before it was added.