### PR TITLE
Add warning to banner to not use with PHI.

### DIFF
--- a/site-overlay/layout.erb
+++ b/site-overlay/layout.erb
@@ -30,6 +30,7 @@
         -->
       <a href="https://github.com/siteadmin/inferno#installation-and-deployment">
         <div>This server is provided for demonstration purposes.</div>
+        <div>Do not use to access sensitive data or Protected Health Information (PHI).</div>
         <div>Data is removed every Sunday at 12:01am ET.</div>
       </a>
     </div>

--- a/static-assets/site/site.css
+++ b/static-assets/site/site.css
@@ -6,7 +6,7 @@
     text-align: right;
     font-size: 1rem;
     position: relative;
-    top: -3.2em;
+    top: -5.2em;
     height: 0;
 }
 


### PR DESCRIPTION
Update the site-wide banner to state:

```
This server is provided for demonstration purposes.
Do not use to access sensitive data or Protected Health Information (PHI).
Data is removed every Sunday at 12:01am ET.
```