### PR TITLE
Fix issue where nginx wasnt properly invalidating cache.

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -24,7 +24,7 @@ http {
   access_log /tmp/nginx.access.log combined;
 
   # use the kernel sendfile
-  sendfile        on;
+  # sendfile        on;  # this causes over-caching because modified timestamps lost in VM
   # prepend http headers before sendfile()
   tcp_nopush     on;
 


### PR DESCRIPTION
Problem: when we deployed new versions of the site, our configuration somehow was set up such that browsers didn't receive a new version of the js & css files,  unless they did a 'hard refresh'.  To get around this, we started appending the version number to the end of the css/js files (eg. `app.js?v2.0.0`) but that was only intended as a temporary workaround and forces us to continuously update the version if we wanted to deploy.

Solution: https://stackoverflow.com/a/13116771

To replicate: Launch docker, visit the front page, change app.js within the `inferno` site, and refresh.  The app.js will be a cached copy because the server returned a 301 since it isn't capable of understanding that there is a new version of the file available.

To demonstrate it works: With this fix in place, perform the above, but after changing app.js the changes should come through into the browser without doing a 'hard refresh'.

We should double-check that streaming isn't affected after deploy, and watch out to make sure this doesn't have any performance side-effects.