### PR TITLE
FI-260: Add Google analytics tag to the Inferno utility to track usage

### DIFF
--- a/site-overlay/layout.erb
+++ b/site-overlay/layout.erb
@@ -1,6 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>
+      (function(w,d,s,l,i){
+        w[l]=w[l]||[];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+        j.async=true;
+        j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+        f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-KC3FP96');
+    </script>
+    <!-- End Google Tag Manager -->
     <title><%=app_name%></title>
     <!-- Required meta tags -->
     <meta charset="utf-8">
@@ -13,6 +25,12 @@
     <link rel="stylesheet" href="/site/site.css?<%=version%>&0">
   </head>
   <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KC3FP96"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
 
   <header>
     <div class="site-header">


### PR DESCRIPTION
This PR adds the Google Tag Manager code (a JavaScript snippet in the `head` tag, and an `iframe` in the `body` tag for noscript situations) as requested by ONC. 

Tested by copying the resulting layout.erb into an inferno instance and ensuring that the JS and iframe show up.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: FI-260
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases: N/A
- [x] Tests/code quality metrics have been run locally and pass: N/A


**Reviewer 1:**

Name: Rob Scanlon
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code -- not necessary, this is a copy/paste from explicit instructions.

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
