### PR TITLE
Add a modified version of the Inferno PR template to the site overlay repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+Pull requests into inferno-site-overlay require the following items to be completed. Submitter and reviewer 
+should check the relevant check boxes when the associated item is done. For items that are not 
+applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
+Requests do not require ticket links.
+
+**Submitter:**
+- [ ] This pull request describes why these changes were made
+- [ ] Internal ticket for this PR:
+- [ ] Internal ticket links to this PR
+- [ ] Internal ticket is properly labeled (Community/Program)
+- [ ] Internal ticket has a justification for its Community/Program label
+- [ ] Code diff has been reviewed for extraneous/missing code
+
+**Reviewer 1:**
+
+Name:
+- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
+      where appropriate, and accomplishes the task's purpose
+- [ ] You have tried to break the code
+
+**Reviewer 2:**
+
+Name:
+- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
+      where appropriate, and accomplishes the task's purpose
+- [ ] You have tried to break the code


### PR DESCRIPTION
This PR adds the PR template that we developed to Inferno to this repository as well. I removed the lines that talked about tests, since this repository doesn't have any tests; we can add them back in if we ever create tests for this repo.