### PR TITLE
Add in the modal for server state to the overlay layout.erb

### DIFF
--- a/site-overlay/layout.erb
+++ b/site-overlay/layout.erb
@@ -79,6 +79,24 @@
     </script>
 
     <%= yield %>
+
+    <!-- global modals -->
+    <div class="modal fade" id="ServerStatusModal" tabindex="-1" role="dialog" aria-labelledby="ServerStatusModalLabel" aria-hidden="true">
+      <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="ServerStatusModalLabel">Server Configuration</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <%= erb(:server_state, {}, {}) %>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <footer class="footer">
       <div class="container row">
         <div class="col-sm text-left">
@@ -88,7 +106,9 @@
           <a target="_blank" href="https://github.com/siteadmin/inferno/issues">Issues</a>
         </div>
         <div class="col-sm text-right">
-          Version <%= version %>
+          <a href="#" data-toggle="modal" data-target="#ServerStatusModal">
+              Version <%= version %>
+          </a>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
Still uses the underlying server state ERB file

Pull requests into inferno-site-overlay require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
