### PR TITLE
FI-443 Update community config with new us core module names

### DIFF
--- a/community-config.yml
+++ b/community-config.yml
@@ -44,4 +44,5 @@ badge_text: COMMUNITY EDITION
 modules:
   - smart
   - argonaut
-  - us_core_r4
+  - uscore_v3.0.0
+  - uscore_v3.0.1


### PR DESCRIPTION
The US Core module names were updated to reflect version and to be more accurate.  The community-config.yml file needs to be updated.  I did this really quickly, but an issue is preventing me from testing it.  Please test before updating.  We should have this fixed before promoting from infernotest.healthit.gov to inferno.healthit.gov.

Pull requests into inferno-site-overlay require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
