### PR TITLE
Add hl7 validator.

### DIFF
--- a/community-config.yml
+++ b/community-config.yml
@@ -40,6 +40,10 @@ include_extras: true
 
 badge_text: COMMUNITY EDITION
 
+# Resource validator options: must be one of "internal" or "external". external_resource_validator_url is only used if resource_validator is set to external.
+resource_validator: external
+external_resource_validator_url: http://validator_service:4567
+
 # module options: one or more must be set.  The first option in the list will be checked by default
 modules:
   - smart

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,4 +52,6 @@ services:
       - inferno_program
   bdt_service:
     image: infernocommunity/inferno-bdt-service
+  validator_service:
+    image: infernocommunity/fhir-validator-wrapper
   


### PR DESCRIPTION
This adds the hl7 validator service and enables it for the community edition of inferno.
