### PR TITLE
Add FHIR Validator App to docker-compose.yml and nginx.conf, on the /validator route

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
     links:
       - inferno:inferno
       - inferno_program:inferno_program
+      - fhir_validator_app:fhir_validator_app
     restart: unless-stopped
     depends_on:
       - inferno
@@ -58,4 +59,9 @@ services:
   validator_service:
     image: infernocommunity/fhir-validator-wrapper
     mem_limit: 1500m
-  
+  fhir_validator_app:
+    image: infernocommunity/fhir-validator-app
+    environment:
+      external_validator_url: http://fhir_validator_wrapper:4567
+      validator_base_path: validator
+    mem_limit: 1000m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,6 @@ services:
   fhir_validator_app:
     image: infernocommunity/fhir-validator-app
     environment:
-      external_validator_url: http://fhir_validator_wrapper:4567
+      external_validator_url: http://validator_service:4567
       validator_base_path: validator
     mem_limit: 1000m

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -95,6 +95,21 @@ http {
       # the port on inferno has to match the EXPOSE in Dockerfile
       proxy_pass http://inferno:4567;
     }
+
+    location /validator {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
+
+      # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
+      proxy_pass http://fhir_validator_app:4567;
+    }
   }
 }
 


### PR DESCRIPTION


Pull requests into inferno-site-overlay require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [ ] This pull request describes why these changes were made
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Internal ticket is properly labeled (Community/Program)
- [ ] Internal ticket has a justification for its Community/Program label
- [ ] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
