### PR TITLE
FI-681: Fix EHR launch scopes

### DIFF
--- a/inferno-config.yml
+++ b/inferno-config.yml
@@ -21,7 +21,7 @@ bind: '0.0.0.0'
 disable_tls_tests: false
 
 # Default scopes
-default_scopes: launch launch/patient offline_access openid profile user/*.* patient/*.*
+default_scopes: launch user/*.read openid fhirUser offline_access
 
 # Log Level: unkown, fatal, error, warn, info, debug
 log_level: info


### PR DESCRIPTION
This branch fixes the obsolete default scopes in the program EHR launch.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-681
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
