### PR TITLE
Add unless-stopped restart policy to all containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,12 +56,15 @@ services:
   bdt_service:
     image: infernocommunity/inferno-bdt-service
     mem_limit: 1000m
+    restart: unless-stopped
   validator_service:
     image: infernocommunity/fhir-validator-wrapper
     mem_limit: 1500m
+    restart: unless-stopped
   fhir_validator_app:
     image: infernocommunity/fhir-validator-app
     environment:
       external_validator_url: http://validator_service:4567
       validator_base_path: validator
     mem_limit: 1000m
+    restart: unless-stopped


### PR DESCRIPTION
The default restart policy for Docker-compose is to not restart a container when docker or the system reboots.

This PR changes that restart policy for all containers in the docker-compose.yml, so they'll automatically restart unless they're explicitly stopped using the Docker Compose cli.

﻿Pull requests into inferno-site-overlay require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-727
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name: @arscan 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
