### PR TITLE
FI-742: add reference server to site-overlay

### DIFF
--- a/community-config.yml
+++ b/community-config.yml
@@ -99,4 +99,29 @@ presets:
     bulk_group_export_endpoint: /Group/5/$export
     # A UI for this launch configuration can be accessed at:
     # https://bulk-data.smarthealthit.org/?auth_type=jwks&jwks=eyJrZXlzIjpbeyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwieCI6InRWekRXUTVxTTFla1JrTzlhY1YyT3JEV19KeWVTNmJhRHJYUHM5dlBPR094YTV6NTVDV3Rwd2dfQkR5T1l0OG4iLCJ5IjoiaHBYSUNaTU5lekQxb01OYWtPcWxHTmgzV1FnQ2RLZlFVcERObGh4X2RLUW8weW1NUGVYS3hpc01tVnFXT2stTCIsImtleV9vcHMiOlsidmVyaWZ5Il0sImV4dCI6dHJ1ZSwia2lkIjoiYzk1MjlhMGFhZWZhNWVhNjU5ZDY1YzQ5MzllY2E5NzYiLCJhbGciOiJFUzM4NCJ9LHsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImQiOiJtOWdKcUdhaDhDOC12bW9zNS02YnA5MDJUUEZHSHZjdFVJekdkMjJMUHlFNm81RDJXRVUxbVdFbTc0bEVleWJQIiwieCI6InRWekRXUTVxTTFla1JrTzlhY1YyT3JEV19KeWVTNmJhRHJYUHM5dlBPR094YTV6NTVDV3Rwd2dfQkR5T1l0OG4iLCJ5IjoiaHBYSUNaTU5lekQxb01OYWtPcWxHTmgzV1FnQ2RLZlFVcERObGh4X2RLUW8weW1NUGVYS3hpc01tVnFXT2stTCIsImtleV9vcHMiOlsic2lnbiJdLCJleHQiOnRydWUsImtpZCI6ImM5NTI5YTBhYWVmYTVlYTY1OWQ2NWM0OTM5ZWNhOTc2IiwiYWxnIjoiRVMzODQifV19&page=1000&stu=4
+  infernotest_healthit_gov:
+    name: FHIR Reference Server
+    uri: https://infernotest.healthit.gov/r4
+    module: onc_program
+    inferno_uri: https://infernotest.healthit.gov/community
+    client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
+    confidential_client: true
+    client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
+    onc_sl_url: https://infernotest.healthit.gov/r4
+    onc_sl_client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
+    onc_sl_confidential_client: true
+    onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
+  inferno_healthit_gov:
+    name: FHIR Reference Server
+    uri: https://inferno.healthit.gov/r4
+    module: onc_program
+    inferno_uri: https://inferno.healthit.gov/community
+    client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
+    confidential_client: true
+    client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
+    onc_sl_url: https://inferno.healthit.gov/r4
+    onc_sl_client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
+    onc_sl_confidential_client: true
+    onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
+
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,9 +69,7 @@ services:
     mem_limit: 1000m
     restart: unless-stopped
   inferno_reference_server:
-    # image: infernocommunity/inferno-reference-server
-    build:
-      context: ../inferno-reference-server
+    image: infernocommunity/inferno-reference-server
     mem_limit: 1500m
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,3 +68,22 @@ services:
       validator_base_path: validator
     mem_limit: 1000m
     restart: unless-stopped
+  inferno_reference_server:
+    image: infernocommunity/inferno-reference-server
+    mem_limit: 1500m
+    restart: unless-stopped
+    environment:
+      - POSTGRES_HOST=db
+    depends_on:
+      - db
+  db:
+    image: postgres:9.6-alpine
+    ports:
+      - '5432:5432'
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    volumes:
+      - fhir-pgdata:/var/lib/postgresql/data
+
+volumes:
+  fhir-pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,9 +37,9 @@ services:
     image: nginx
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      # - /etc/ssl/certs/inferno:/etc/ssl/certs/inferno:ro
+      - /etc/ssl/certs/inferno:/etc/ssl/certs/inferno:ro
       # to use tls on localhost for development, comment out above line and uncomment below
-      - ./nginx/development-certs:/etc/ssl/certs/inferno:ro
+      # - ./nginx/development-certs:/etc/ssl/certs/inferno:ro
       - ./static-assets/:/var/www/inferno/public/
     ports:
       - "80:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,9 +37,9 @@ services:
     image: nginx
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - /etc/ssl/certs/inferno:/etc/ssl/certs/inferno:ro
+      # - /etc/ssl/certs/inferno:/etc/ssl/certs/inferno:ro
       # to use tls on localhost for development, comment out above line and uncomment below
-      # - ./nginx/development-certs:/etc/ssl/certs/inferno:ro
+      - ./nginx/development-certs:/etc/ssl/certs/inferno:ro
       - ./static-assets/:/var/www/inferno/public/
     ports:
       - "80:80"
@@ -69,7 +69,9 @@ services:
     mem_limit: 1000m
     restart: unless-stopped
   inferno_reference_server:
-    image: infernocommunity/inferno-reference-server
+    # image: infernocommunity/inferno-reference-server
+    build:
+      context: ../inferno-reference-server
     mem_limit: 1500m
     restart: unless-stopped
     environment:
@@ -78,12 +80,11 @@ services:
       - db
   db:
     image: postgres:9.6-alpine
-    ports:
-      - '5432:5432'
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - fhir-pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
 
 volumes:
   fhir-pgdata:

--- a/inferno-config.yml
+++ b/inferno-config.yml
@@ -95,15 +95,27 @@ bulk_data_jwks:
     
 # preset fhir servers: optional. Minimally requires name, uri, module, optional inferno_uri, client_id, client_secret, scopes, instructions link
 presets:
-  reference_server:
+  infernotest_healthit_gov:
     name: FHIR Reference Server
-    uri: http://localhost:8080/r4
+    uri: https://infernotest.healthit.gov/r4
     module: onc_program
-    inferno_uri: http://localhost:4567
+    inferno_uri: https://infernotest.healthit.gov/inferno
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
-    onc_sl_url: http://localhost:8080/r4
+    onc_sl_url: https://infernotest.healthit.gov/r4
+    onc_sl_client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
+    onc_sl_confidential_client: true
+    onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
+  inferno_healthit_gov:
+    name: FHIR Reference Server
+    uri: https://inferno.healthit.gov/r4
+    module: onc_program
+    inferno_uri: https://inferno.healthit.gov/inferno
+    client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
+    confidential_client: true
+    client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
+    onc_sl_url: https://inferno.healthit.gov/r4
     onc_sl_client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     onc_sl_confidential_client: true
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -111,7 +111,7 @@ http {
       proxy_pass http://fhir_validator_app:4567;
     }
 
-    location /r4/{
+    location /r4 {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;
@@ -125,7 +125,7 @@ http {
       proxy_pass http://inferno_reference_server:8080/r4;
     }
 
-    location /oauth/{
+    location /oauth {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;
@@ -139,7 +139,7 @@ http {
       proxy_pass http://inferno_reference_server:8080/oauth;
     }
 
-    location /reference-server/{
+    location /reference-server {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_redirect off;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -120,6 +120,8 @@ http {
       chunked_transfer_encoding off;
       proxy_buffering off;
       proxy_cache off;
+      proxy_send_timeout 600;
+      proxy_read_timeout 600;
 
       # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
       proxy_pass http://inferno_reference_server:8080/r4;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -57,7 +57,7 @@ http {
     # maximum accepted body size of client request
     client_max_body_size 4G;
     # the server will close connections after this time
-    keepalive_timeout 120;
+    keepalive_timeout 600;
 
     location / {
       rewrite ^/(index.html)?$ /landing last;
@@ -111,10 +111,9 @@ http {
       proxy_pass http://fhir_validator_app:4567;
     }
 
-    location /reference-server/ {
+    location /r4/{
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto https;
       proxy_redirect off;
       proxy_set_header Connection '';
       proxy_http_version 1.1;
@@ -123,8 +122,35 @@ http {
       proxy_cache off;
 
       # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
-      proxy_pass http://inferno_reference_server:8080/;
+      proxy_pass http://inferno_reference_server:8080/r4/;
+    }
+
+    location /oauth/{
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
+
+      # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
+      proxy_pass http://inferno_reference_server:8080/oauth/;
+    }
+
+    location /reference-server/{
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
+
+      # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
+      proxy_pass http://inferno_reference_server:8080/reference-server/;
     }
   }
 }
-

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -110,6 +110,21 @@ http {
       # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
       proxy_pass http://fhir_validator_app:4567;
     }
+
+    location /reference-server/ {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto https;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
+
+      # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
+      proxy_pass http://inferno_reference_server:8080/;
+    }
   }
 }
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -28,7 +28,7 @@ http {
   # prepend http headers before sendfile()
   tcp_nopush     on;
 
-  keepalive_timeout  60;
+  keepalive_timeout  600;
   tcp_nodelay        on;
 
   gzip  on;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -122,7 +122,7 @@ http {
       proxy_cache off;
 
       # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
-      proxy_pass http://inferno_reference_server:8080/r4/;
+      proxy_pass http://inferno_reference_server:8080/r4;
     }
 
     location /oauth/{
@@ -136,7 +136,7 @@ http {
       proxy_cache off;
 
       # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
-      proxy_pass http://inferno_reference_server:8080/oauth/;
+      proxy_pass http://inferno_reference_server:8080/oauth;
     }
 
     location /reference-server/{
@@ -150,7 +150,7 @@ http {
       proxy_cache off;
 
       # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
-      proxy_pass http://inferno_reference_server:8080/reference-server/;
+      proxy_pass http://inferno_reference_server:8080/reference-server;
     }
   }
 }


### PR DESCRIPTION
This PR adds the reference-server and its db to inferno-site-overlay. 

NOTE: To test this, you will have to pull down `inferno-reference-server` from this PR: https://github.com/inferno-community/inferno-reference-server/pull/4, build that branch with `docker build -t infernocommunity/inferno-reference-server:latest .`, prior to running `docker-compose up --force-recreate` in this branch.

ALSO: Be sure to use your local machine's IP, rather than `localhost`, during testing, so that the different applications can speak with one another.

﻿Pull requests into inferno-site-overlay require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-742
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
