### PR TITLE
Disallow TLS 1.1, and forward the https header through the reverse proxies

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -53,6 +53,7 @@ http {
     listen 443 default_server ssl;
     ssl_certificate /etc/ssl/certs/inferno/inferno.crt;
     ssl_certificate_key /etc/ssl/certs/inferno/inferno.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
 
     # maximum accepted body size of client request
     client_max_body_size 4G;
@@ -114,6 +115,7 @@ http {
     location /r4 {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto https;
       proxy_redirect off;
       proxy_set_header Connection '';
       proxy_http_version 1.1;
@@ -130,6 +132,7 @@ http {
     location /oauth {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto https;
       proxy_redirect off;
       proxy_set_header Connection '';
       proxy_http_version 1.1;
@@ -144,6 +147,7 @@ http {
     location /reference-server {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto https;
       proxy_redirect off;
       proxy_set_header Connection '';
       proxy_http_version 1.1;


### PR DESCRIPTION
TLS 1.1 connections are specifically disallowed by the ONC Final Rule, so this PR disallows them in the site-overlay config (globally, not just for the reference server).

This PR also ensures that the https scheme is forwarded through the reverse proxies for the reference-server (needed for proper URL writing).

Pull requests into inferno-site-overlay require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- N/A Internal ticket for this PR:
- N/A Internal ticket links to this PR
- N/A Internal ticket is properly labeled (Community/Program)
- N/A Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
