### PR TITLE
Update community config

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,16 @@ make git_update
 make inferno_docker_rebuild
 docker-compose up -d
 ```
+
+## Testing locally
+
+In order to test locally the `nginx_server` configuration in `docker-compose.yml` must be modified.
+Specifically, in the volume mounting:
+
+`- /etc/ssl/certs/inferno:/etc/ssl/certs/inferno:ro` must be commented out
+
+and
+
+`- ./nginx/development-certs:/etc/ssl/certs/inferno:ro` should be uncommented.
+
+once that's done you can start it with `docker-compose up -d`.

--- a/community-config.yml
+++ b/community-config.yml
@@ -102,7 +102,7 @@ presets:
   infernotest_healthit_gov:
     name: FHIR Reference Server
     uri: https://infernotest.healthit.gov/r4
-    module: onc_program
+    module: uscore_v3.1.0
     inferno_uri: https://infernotest.healthit.gov/community
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true
@@ -114,7 +114,7 @@ presets:
   inferno_healthit_gov:
     name: FHIR Reference Server
     uri: https://inferno.healthit.gov/r4
-    module: onc_program
+    module: uscore_v3.1.0
     inferno_uri: https://inferno.healthit.gov/community
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true


### PR DESCRIPTION
Currently the community edition config is improperly configured to use the `onc_program` module which results in a "Unknown module" error.  This PR fixes that by changing the configuration to use the us core 3.1.0 tests instead.  It also adds some information to the readme about how to test site-overlay locally.

**Submitter:**
- [ ] This pull request describes why these changes were made
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Internal ticket is properly labeled (Community/Program)
- [ ] Internal ticket has a justification for its Community/Program label
- [ ] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
