### PR TITLE
FI-772: Update reference-server routes in nginx/inferno configs

### DIFF
--- a/community-config.yml
+++ b/community-config.yml
@@ -101,25 +101,25 @@ presets:
     # https://bulk-data.smarthealthit.org/?auth_type=jwks&jwks=eyJrZXlzIjpbeyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwieCI6InRWekRXUTVxTTFla1JrTzlhY1YyT3JEV19KeWVTNmJhRHJYUHM5dlBPR094YTV6NTVDV3Rwd2dfQkR5T1l0OG4iLCJ5IjoiaHBYSUNaTU5lekQxb01OYWtPcWxHTmgzV1FnQ2RLZlFVcERObGh4X2RLUW8weW1NUGVYS3hpc01tVnFXT2stTCIsImtleV9vcHMiOlsidmVyaWZ5Il0sImV4dCI6dHJ1ZSwia2lkIjoiYzk1MjlhMGFhZWZhNWVhNjU5ZDY1YzQ5MzllY2E5NzYiLCJhbGciOiJFUzM4NCJ9LHsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImQiOiJtOWdKcUdhaDhDOC12bW9zNS02YnA5MDJUUEZHSHZjdFVJekdkMjJMUHlFNm81RDJXRVUxbVdFbTc0bEVleWJQIiwieCI6InRWekRXUTVxTTFla1JrTzlhY1YyT3JEV19KeWVTNmJhRHJYUHM5dlBPR094YTV6NTVDV3Rwd2dfQkR5T1l0OG4iLCJ5IjoiaHBYSUNaTU5lekQxb01OYWtPcWxHTmgzV1FnQ2RLZlFVcERObGh4X2RLUW8weW1NUGVYS3hpc01tVnFXT2stTCIsImtleV9vcHMiOlsic2lnbiJdLCJleHQiOnRydWUsImtpZCI6ImM5NTI5YTBhYWVmYTVlYTY1OWQ2NWM0OTM5ZWNhOTc2IiwiYWxnIjoiRVMzODQifV19&page=1000&stu=4
   infernotest_healthit_gov:
     name: Inferno Reference Server
-    uri: https://infernotest.healthit.gov/r4
+    uri: https://infernotest.healthit.gov/reference-server/r4
     module: uscore_v3.1.0
     inferno_uri: https://infernotest.healthit.gov/community
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
-    onc_sl_url: https://infernotest.healthit.gov/r4
+    onc_sl_url: https://infernotest.healthit.gov/reference-server/r4
     onc_sl_client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     onc_sl_confidential_client: true
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
   inferno_healthit_gov:
     name: Inferno Reference Server
-    uri: https://inferno.healthit.gov/r4
+    uri: https://inferno.healthit.gov/reference-server/r4
     module: uscore_v3.1.0
     inferno_uri: https://inferno.healthit.gov/community
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
-    onc_sl_url: https://inferno.healthit.gov/r4
+    onc_sl_url: https://inferno.healthit.gov/reference-server/r4
     onc_sl_client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     onc_sl_confidential_client: true
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET

--- a/inferno-config.yml
+++ b/inferno-config.yml
@@ -99,7 +99,7 @@ presets:
     name: Inferno Reference Server
     uri: https://infernotest.healthit.gov/reference-server/r4
     module: onc_program
-    # inferno_uri: https://infernotest.healthit.gov/inferno
+    inferno_uri: https://infernotest.healthit.gov/inferno
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
@@ -112,7 +112,7 @@ presets:
     name: Inferno Reference Server
     uri: https://inferno.healthit.gov/reference-server/r4
     module: onc_program
-    # inferno_uri: https://inferno.healthit.gov/inferno
+    inferno_uri: https://inferno.healthit.gov/inferno
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET

--- a/inferno-config.yml
+++ b/inferno-config.yml
@@ -97,26 +97,26 @@ bulk_data_jwks:
 presets:
   infernotest_healthit_gov:
     name: Inferno Reference Server
-    uri: https://infernotest.healthit.gov/r4
+    uri: https://infernotest.healthit.gov/reference-server/r4
     module: onc_program
-    inferno_uri: https://infernotest.healthit.gov/inferno
+    # inferno_uri: https://infernotest.healthit.gov/inferno
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
-    onc_sl_url: https://infernotest.healthit.gov/r4
+    onc_sl_url: https://infernotest.healthit.gov/reference-server/r4
     onc_sl_client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     onc_sl_confidential_client: true
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
     patient_ids: "76,184"
   inferno_healthit_gov:
     name: Inferno Reference Server
-    uri: https://inferno.healthit.gov/r4
+    uri: https://inferno.healthit.gov/reference-server/r4
     module: onc_program
-    inferno_uri: https://inferno.healthit.gov/inferno
+    # inferno_uri: https://inferno.healthit.gov/inferno
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
-    onc_sl_url: https://inferno.healthit.gov/r4
+    onc_sl_url: https://inferno.healthit.gov/reference-server/r4
     onc_sl_client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     onc_sl_confidential_client: true
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -68,7 +68,7 @@ http {
     location @app {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto https;
+      proxy_set_header X-Forwarded-Proto $scheme;
       proxy_redirect off;
       proxy_set_header Connection '';
       proxy_http_version 1.1;
@@ -85,7 +85,7 @@ http {
       root /var/www/inferno/public;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto https;
+      proxy_set_header X-Forwarded-Proto $scheme;
       proxy_redirect off;
       proxy_set_header Connection '';
       proxy_http_version 1.1;
@@ -100,7 +100,7 @@ http {
     location /validator {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto https;
+      proxy_set_header X-Forwarded-Proto $scheme;
       proxy_redirect off;
       proxy_set_header Connection '';
       proxy_http_version 1.1;
@@ -112,42 +112,10 @@ http {
       proxy_pass http://fhir_validator_app:4567;
     }
 
-    location /r4 {
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto https;
-      proxy_redirect off;
-      proxy_set_header Connection '';
-      proxy_http_version 1.1;
-      chunked_transfer_encoding off;
-      proxy_buffering off;
-      proxy_cache off;
-      proxy_send_timeout 600;
-      proxy_read_timeout 600;
-
-      # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
-      proxy_pass http://inferno_reference_server:8080/r4;
-    }
-
-    location /oauth {
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto https;
-      proxy_redirect off;
-      proxy_set_header Connection '';
-      proxy_http_version 1.1;
-      chunked_transfer_encoding off;
-      proxy_buffering off;
-      proxy_cache off;
-
-      # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
-      proxy_pass http://inferno_reference_server:8080/oauth;
-    }
-
     location /reference-server {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto https;
+      proxy_set_header X-Forwarded-Proto $scheme;
       proxy_redirect off;
       proxy_set_header Connection '';
       proxy_http_version 1.1;


### PR DESCRIPTION
Since the inferno-reference-server was updated to respond to everything with a `/reference-server` prefix, we have to update our routes in Nginx accordingly.

This PR also updates the inferno/community configs to route to those new routes.

ALSO: this PR updates the nginx config to pass the X-forwarded-proto header as whatever protocol the URL was called with. This will allow the same site-overlay configuration to work in development as in production.

﻿Pull requests into inferno-site-overlay require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
