### PR TITLE
Build the reference-server DB container with the same pre-seeded data we use in the reference-server compose file

### DIFF
--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -1,0 +1,2 @@
+FROM postgres:9.6-alpine
+COPY initdb.sql /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,9 @@ services:
     depends_on:
       - db
   db:
-    image: postgres:9.6-alpine
+    build:
+      context: .
+      dockerfile: Dockerfile.database
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:


### PR DESCRIPTION
Previously, we were building the Reference Server's Postgres DB container using a Postgres Alpine image. This gave us a completely blank DB. 

This PR builds the DB container using the same Dockerfile.database we use in `inferno-reference-server`, because we don't want a completely blank db, we want it to be seeded with patient data and StructureDefinitions for US Core testing.

﻿Pull requests into inferno-site-overlay require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Internal ticket is properly labeled (Community/Program) N/A
- [x] Internal ticket has a justification for its Community/Program label N/A
- [x] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
