### PR TITLE
Fix presets with correct patient_ids add sample public client id.

### DIFF
--- a/inferno-config.yml
+++ b/inferno-config.yml
@@ -107,7 +107,8 @@ presets:
     onc_sl_client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     onc_sl_confidential_client: true
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
-    patient_ids: "76,184"
+    onc_public_client_id: SAMPLE_PUBLIC_CLIENT_ID
+    patient_ids: "76,185"
   inferno_healthit_gov:
     name: Inferno Reference Server
     uri: https://inferno.healthit.gov/reference-server/r4
@@ -120,4 +121,5 @@ presets:
     onc_sl_client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     onc_sl_confidential_client: true
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
-    patient_ids: "76,184"
+    onc_public_client_id: SAMPLE_PUBLIC_CLIENT_ID
+    patient_ids: "76,185"


### PR DESCRIPTION
When we rebuilt the data, our patient_ids changed slightly somehow.  Update that.  And we neglected to add in the public_client_id as a preset for our server as well.
