### PR TITLE
Update community-config.yml to use community validator

### DIFF
--- a/community-config.yml
+++ b/community-config.yml
@@ -42,7 +42,7 @@ badge_text: COMMUNITY EDITION
 
 # Resource validator options: must be one of "internal" or "external". external_resource_validator_url is only used if resource_validator is set to external.
 resource_validator: external
-external_resource_validator_url: http://validator_service:4567
+external_resource_validator_url: http://community_validator_service:4567
 
 # module options: one or more must be set.  The first option in the list will be checked by default
 modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     command: bundle exec rackup -o 0.0.0.0
     depends_on:
       - bdt_service
+      - community_validator_service
     restart: unless-stopped
     mem_limit: 2000m
   nginx_server:


### PR DESCRIPTION
https://github.com/onc-healthit/inferno/pull/476 requires that inferno use `fhir-validator-service` which supports the `/version` route.  Inferno will not start until it can confirm access to the validator.