### PR TITLE
FI-895: update US Core patients in inferno-reference-server

### DIFF
--- a/inferno-config.yml
+++ b/inferno-config.yml
@@ -108,7 +108,7 @@ presets:
     onc_sl_confidential_client: true
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
     onc_public_client_id: SAMPLE_PUBLIC_CLIENT_ID
-    patient_ids: "76,185"
+    patient_ids: "104,455"
     bulk_url:  https://inferno.healthit.gov/bulk-data-server/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1Ijo0fQ/fhir
     bulk_token_endpoint: https://inferno.healthit.gov/bulk-data-server/auth/token
     bulk_client_id: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJlZ2lzdHJhdGlvbi10b2tlbiJ9.eyJqd2tzX3VybCI6Imh0dHBzOi8vaW5mZXJuby5oZWFsdGhpdC5nb3YvaW5mZXJuby8ud2VsbC1rbm93bi9qd2tzLmpzb24iLCJhY2Nlc3NUb2tlbnNFeHBpcmVJbiI6MTUsImlhdCI6MTU5OTE1NzgyMX0.-wulnE05BlY_Zcm5iP77Meqxr6iNiYxBsOADB5CGE8I
@@ -127,7 +127,7 @@ presets:
     onc_sl_confidential_client: true
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
     onc_public_client_id: SAMPLE_PUBLIC_CLIENT_ID
-    patient_ids: "76,185"
+    patient_ids: "104,455"
     bulk_url:  https://inferno.healthit.gov/bulk-data-server/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1Ijo0fQ/fhir
     bulk_token_endpoint: https://inferno.healthit.gov/bulk-data-server/auth/token
     bulk_client_id: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJlZ2lzdHJhdGlvbi10b2tlbiJ9.eyJqd2tzX3VybCI6Imh0dHBzOi8vaW5mZXJuby5oZWFsdGhpdC5nb3YvaW5mZXJuby8ud2VsbC1rbm93bi9qd2tzLmpzb24iLCJhY2Nlc3NUb2tlbnNFeHBpcmVJbiI6MTUsImlhdCI6MTU5OTE1NzgyMX0.-wulnE05BlY_Zcm5iP77Meqxr6iNiYxBsOADB5CGE8I


### PR DESCRIPTION
This PR moves the patients generated in `uscore-data-script`, and currently in review in `inferno-reference-server`/`bulk-data-server`, into this repo as well. It also updates the patient IDs in `inferno-config.yml` to match the IDs of the new patients.

Pull requests into inferno-site-overlay require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: `FI-895`
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
