### PR TITLE
fi-984: use fhir-validator-service tagged version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     mem_limit: 1000m
     restart: unless-stopped
   validator_service:
-    image: infernocommunity/fhir-validator-wrapper
+    image: infernocommunity/fhir-validator-service:v0.1.0
     mem_limit: 1500m
     restart: unless-stopped
   community_validator_service:


### PR DESCRIPTION
This PR pins inferno-program's validator to a specific version of fhir-validator-service, so we can begin the deprecation process for fhir-validator-wrapper. This version is the same as what is currently in fhir-validator-wrapper, so this should result in no change in functionality.

The community validator service remains unaffected, since we want the latest version of `fhir-validator-service` for community/the standalone validator app.

Pull requests into inferno-site-overlay require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
