### PR TITLE
Update the program config to use infernotest's bulk data server where needed

### DIFF
--- a/inferno-config.yml
+++ b/inferno-config.yml
@@ -109,9 +109,9 @@ presets:
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
     onc_public_client_id: SAMPLE_PUBLIC_CLIENT_ID
     patient_ids: "104,455"
-    bulk_url:  https://inferno.healthit.gov/bulk-data-server/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1Ijo0fQ/fhir
-    bulk_token_endpoint: https://inferno.healthit.gov/bulk-data-server/auth/token
-    bulk_client_id: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJlZ2lzdHJhdGlvbi10b2tlbiJ9.eyJqd2tzX3VybCI6Imh0dHBzOi8vaW5mZXJuby5oZWFsdGhpdC5nb3YvaW5mZXJuby8ud2VsbC1rbm93bi9qd2tzLmpzb24iLCJhY2Nlc3NUb2tlbnNFeHBpcmVJbiI6MTUsImlhdCI6MTU5OTE1NzgyMX0.-wulnE05BlY_Zcm5iP77Meqxr6iNiYxBsOADB5CGE8I
+    bulk_url:  https://infernotest.healthit.gov/bulk-data-server/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1Ijo0fQ/fhir
+    bulk_token_endpoint: https://infernotest.healthit.gov/bulk-data-server/auth/token
+    bulk_client_id: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJlZ2lzdHJhdGlvbi10b2tlbiJ9.eyJqd2tzX3VybCI6Imh0dHBzOi8vaW5mZXJub3Rlc3QuaGVhbHRoaXQuZ292L2luZmVybm8vLndlbGwta25vd24vandrcy5qc29uIiwiYWNjZXNzVG9rZW5zRXhwaXJlSW4iOjE1LCJpYXQiOjE2MDMxMTQxMzB9.giM_eScI6SaNUOnmbE0W9dPuwl1xEPLN4thXBUDcSLc
     bulk_scope: system/*.read
     group_id: 3d7d2344-ca49-40ac-9e1f-88b40fff3bd9
   inferno_healthit_gov:


### PR DESCRIPTION
While doing some work in inferno-site-overlay, I noticed that the infernotest preset for inferno program used inferno.healthit.gov as the base URL for some of the bulk data fields. This PR corrects that.

I also updated the client ID from infernotest's bulk data server, which is why that changed. 

Pull requests into inferno-site-overlay require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Internal ticket is properly labeled (Community/Program) N/A
- [x] Internal ticket has a justification for its Community/Program label N/A
- [x] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
