### PR TITLE
FI-997 fix reference server port issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,6 @@ services:
     restart: unless-stopped
     environment:
       - POSTGRES_HOST=db
-      - CUSTOM_DEPLOYMENT_PORT=8443
     depends_on:
       - db
   db:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -69,6 +69,7 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
       proxy_redirect off;
       proxy_set_header Connection '';
       proxy_http_version 1.1;
@@ -86,6 +87,7 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
       proxy_redirect off;
       proxy_set_header Connection '';
       proxy_http_version 1.1;
@@ -101,6 +103,7 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
       proxy_redirect off;
       proxy_set_header Connection '';
       proxy_http_version 1.1;
@@ -113,24 +116,26 @@ http {
     }
 
     location /validatorapi/ {
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header Host $http_host;
-          proxy_set_header X-Forwarded-Proto $scheme;
-          proxy_redirect off;
-          proxy_set_header Connection '';
-          proxy_http_version 1.1;
-          chunked_transfer_encoding off;
-          proxy_buffering off;
-          proxy_cache off;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
+      proxy_redirect off;
+      proxy_set_header Connection '';
+      proxy_http_version 1.1;
+      chunked_transfer_encoding off;
+      proxy_buffering off;
+      proxy_cache off;
 
-          # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
-          proxy_pass http://community_validator_service:4567/;
-        }
+      # the port on fhir_validator_app has to match the EXPOSE in Dockerfile
+      proxy_pass http://community_validator_service:4567/;
+    }
 
     location /reference-server {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
       proxy_redirect off;
       proxy_set_header Connection '';
       proxy_http_version 1.1;
@@ -146,6 +151,7 @@ http {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header Host $http_host;
       proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Port $server_port;
       proxy_redirect off;
       proxy_set_header Connection '';
       proxy_http_version 1.1;


### PR DESCRIPTION
This PR adds an `X-Forwarded-Port` header to the nginx.conf locations. This is designed to fix an issue with the reference server, where it was defaulting to a different port than expected for SSL requests, but we apply it to all the locations to ensure we don't run into this issue again.

Pull requests into inferno-site-overlay require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes reason the PR is being made
- [x] Internal ticket for this PR: FI-997
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] You have tried to break the code
