### PR TITLE
Update for Inferno Community v2.11.0

### DIFF
--- a/community-config.yml
+++ b/community-config.yml
@@ -35,6 +35,12 @@ badge_text: COMMUNITY EDITION
 resource_validator: external
 external_resource_validator_url: http://community_validator_service:4567
 
+# FHIRPath evaluator options: must be one of "internal" or "external".
+# external_fhirpath_evaluator_url is only used if fhirpath_evaluator is set to
+# external.
+fhirpath_evaluator: external
+external_fhirpath_evaluator_url: http://community_validator_service:4567
+
 # module options: one or more must be set.  The first option in the list will be checked by default
 modules:
   - smart
@@ -91,9 +97,9 @@ presets:
     # A UI for this launch configuration can be accessed at:
     # https://bulk-data.smarthealthit.org/?auth_type=jwks&jwks=eyJrZXlzIjpbeyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwieCI6InRWekRXUTVxTTFla1JrTzlhY1YyT3JEV19KeWVTNmJhRHJYUHM5dlBPR094YTV6NTVDV3Rwd2dfQkR5T1l0OG4iLCJ5IjoiaHBYSUNaTU5lekQxb01OYWtPcWxHTmgzV1FnQ2RLZlFVcERObGh4X2RLUW8weW1NUGVYS3hpc01tVnFXT2stTCIsImtleV9vcHMiOlsidmVyaWZ5Il0sImV4dCI6dHJ1ZSwia2lkIjoiYzk1MjlhMGFhZWZhNWVhNjU5ZDY1YzQ5MzllY2E5NzYiLCJhbGciOiJFUzM4NCJ9LHsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImQiOiJtOWdKcUdhaDhDOC12bW9zNS02YnA5MDJUUEZHSHZjdFVJekdkMjJMUHlFNm81RDJXRVUxbVdFbTc0bEVleWJQIiwieCI6InRWekRXUTVxTTFla1JrTzlhY1YyT3JEV19KeWVTNmJhRHJYUHM5dlBPR094YTV6NTVDV3Rwd2dfQkR5T1l0OG4iLCJ5IjoiaHBYSUNaTU5lekQxb01OYWtPcWxHTmgzV1FnQ2RLZlFVcERObGh4X2RLUW8weW1NUGVYS3hpc01tVnFXT2stTCIsImtleV9vcHMiOlsic2lnbiJdLCJleHQiOnRydWUsImtpZCI6ImM5NTI5YTBhYWVmYTVlYTY1OWQ2NWM0OTM5ZWNhOTc2IiwiYWxnIjoiRVMzODQifV19&page=1000&stu=4
   infernotest_healthit_gov:
-    name: Inferno Reference Server (US Core v3.1.0)
+    name: Inferno Reference Server (US Core v3.1.1)
     uri: https://infernotest.healthit.gov/reference-server/r4
-    module: uscore_v3.1.0
+    module: uscore_v3.1.1
     inferno_uri: https://infernotest.healthit.gov/community
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true
@@ -103,9 +109,9 @@ presets:
     onc_sl_confidential_client: true
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
   inferno_healthit_gov:
-    name: Inferno Reference Server (US Core v3.1.0)
+    name: Inferno Reference Server (US Core v3.1.1)
     uri: https://inferno.healthit.gov/reference-server/r4
-    module: uscore_v3.1.0
+    module: uscore_v3.1.1
     inferno_uri: https://inferno.healthit.gov/community
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true

--- a/community-config.yml
+++ b/community-config.yml
@@ -40,7 +40,6 @@ modules:
   - smart
   - bdt
   - argonaut
-  - uscore_v3.1.0
   - uscore_v3.1.1
 
 presets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,9 @@ services:
     image: nginx
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      # - /etc/ssl/certs/inferno:/etc/ssl/certs/inferno:ro
+      - /etc/ssl/certs/inferno:/etc/ssl/certs/inferno:ro
       # to use tls on localhost for development, comment out above line and uncomment below
-      - ./nginx/development-certs:/etc/ssl/certs/inferno:ro
+      # - ./nginx/development-certs:/etc/ssl/certs/inferno:ro
       - ./static-assets/:/var/www/inferno/public/
     ports:
       - "80:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ./bloom:/var/www/inferno/resources/terminology/validators/bloom
     # run the application
     working_dir: /var/www/inferno
-    command: bundle exec rackup -o 0.0.0.0
+    command: bin/run.sh
     depends_on:
       - bdt_service
       - community_validator_service
@@ -38,9 +38,9 @@ services:
     image: nginx
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - /etc/ssl/certs/inferno:/etc/ssl/certs/inferno:ro
+      # - /etc/ssl/certs/inferno:/etc/ssl/certs/inferno:ro
       # to use tls on localhost for development, comment out above line and uncomment below
-      # - ./nginx/development-certs:/etc/ssl/certs/inferno:ro
+      - ./nginx/development-certs:/etc/ssl/certs/inferno:ro
       - ./static-assets/:/var/www/inferno/public/
     ports:
       - "80:80"


### PR DESCRIPTION
Inferno v2.11.0 has a couple changes that require changes to site-overlay.  The two major changes are the removal of US Core 3.1.0 tests and a change to the persistence implementation. The list of all changes can be found in the release notes.