### PR TITLE
Add IPS and update docker to pull new releases only.

### DIFF
--- a/community-config.yml
+++ b/community-config.yml
@@ -45,7 +45,7 @@ external_fhirpath_evaluator_url: http://community_validator_service:4567
 modules:
   - smart
   - bdt
-  - argonaut
+  - ips
   - uscore_v3.1.1
 
 presets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.2'
 services:
   # the main ruby server
   inferno_program:
-    image: onchealthit/inferno-program:latest
+    image: onchealthit/inferno-program:release-latest
     volumes:
       # SITE-specific overlays
       - ./site-overlay/layout.erb:/var/www/inferno/lib/app/views/layout.erb
@@ -17,7 +17,7 @@ services:
     restart: unless-stopped
     mem_limit: 2000m
   inferno:
-    image: onchealthit/inferno:latest
+    image: onchealthit/inferno:release-latest
     volumes:
       # SITE-specific overlays
       - ./site-overlay/layout.erb:/var/www/inferno/lib/app/views/layout.erb


### PR DESCRIPTION
This updates docker-compose to only pull the latest release now that we are no longer using development branch as an intermediary.  Also updates community-config to match what is in the inferno repository.