### PR TITLE
Add server base URL variable to bulk data server config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,8 @@ services:
     image: infernocommunity/bulk-data-server
     mem_limit: 1500m
     restart: unless-stopped
+    environment:
+      - SERVER_BASE_URL=https://inferno.healthit.gov
 
 volumes:
   fhir-pgdata:


### PR DESCRIPTION
This PR adds the `SERVER_BASE_URL` parameter that's needed for the Bulk Data Server. By default it's set to `https://inferno.healthit.gov`; to test, change it to `http://<your_computers_ip>`.