### PR TITLE
Update program validator to 1.2.0, and add in the external validator version var to inferno-config.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     mem_limit: 1000m
     restart: unless-stopped
   validator_service:
-    image: infernocommunity/fhir-validator-service:v0.1.1
+    image: infernocommunity/fhir-validator-service:v1.2.0
     mem_limit: 1500m
     restart: unless-stopped
   community_validator_service:

--- a/inferno-config.yml
+++ b/inferno-config.yml
@@ -44,6 +44,10 @@ badge_text: PROGRAM EDITION
 resource_validator: external
 external_resource_validator_url: http://validator_service:4567
 
+# The expected version of the external validator. The app will display a warning if
+# the found version doesn't match the expected version exactly.
+external_resource_validator_version: '1.2.0'
+
 # module options: one or more must be set.  The first option in the list will be checked by default
 modules:
   - onc_program


### PR DESCRIPTION
# Summary

Updates the program validator service to v1.2.0, and adds in the needed `external_resource_validator_version` to `inferno-config.yml`.

## Testing

Get the latest validator by running `docker-compose pull` in this repository
Build https://github.com/onc-healthit/inferno-program/pull/246 locally by checking out that branch and running `docker build -t onchealthit/inferno-program:release-latest .` in inferno-program
Run `docker-compose up --force-recreate` in this repository to stand all the services up, and ensure inferno-program runs and does not complain about a validator version mismatch

(optional) downgrade the `validator_service` version locally in `docker-compose.yml`, repeat above, and ensure that inferno-program does complain this time.