### PR TITLE
Add sig to bulk data keys as introduced in Inferno Program v1.7.0

### DIFF
--- a/inferno-config.yml
+++ b/inferno-config.yml
@@ -58,6 +58,7 @@ bulk_data_jwks:
       crv: P-384
       x: JQKTsV6PT5Szf4QtDA1qrs0EJ1pbimQmM2SKvzOlIAqlph3h1OHmZ2i7MXahIF2C
       y: bRWWQRJBgDa6CTgwofYrHjVGcO-A7WNEnu4oJA5OUJPPPpczgx1g2NsfinK-D2Rw
+      use: sig
       key_ops:
         - verify
       ext: true
@@ -77,6 +78,7 @@ bulk_data_jwks:
       alg: RS384
       n: vjbIzTqiY8K8zApeNng5ekNNIxJfXAue9BjoMrZ9Qy9m7yIA-tf6muEupEXWhq70tC7vIGLqJJ4O8m7yiH8H2qklX2mCAMg3xG3nbykY2X7JXtW9P8VIdG0sAMt5aZQnUGCgSS3n0qaooGn2LUlTGIR88Qi-4Nrao9_3Ki3UCiICeCiAE224jGCg0OlQU6qj2gEB3o-DWJFlG_dz1y-Mxo5ivaeM0vWuodjDrp-aiabJcSF_dx26sdC9dZdBKXFDq0t19I9S9AyGpGDJwzGRtWHY6LsskNHLvo8Zb5AsJ9eRZKpnh30SYBZI9WHtzU85M9WQqdScR69Vyp-6Uhfbvw
       e: AQAB
+      use: sig
       key_ops:
         - verify
       ext: true


### PR DESCRIPTION
The inferno.healthit.gov instance of inferno-program was never updated to reflect the addition of the `use: sig` parameter to the bulk data public keys.  This should have been done when deploying v1.7.0 of inferno-program.